### PR TITLE
Set multiple cursors after align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.0.7 - 2024-12-27
+
+- Set multiple cursors after align
+
 ## v0.0.6 - 2023-03-26
 
 - Fix packaging

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -4,7 +4,8 @@
 
   ```
   npm install
-  npm run compile
+  npm run compile && npm run mocha
+  npm test
   npx vsce package
   code --install-extension=align-columns-X.X.X.vsix
   ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "align-columns",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "align-columns",
-            "version": "0.0.6",
+            "version": "0.0.7",
             "license": "MIT",
             "devDependencies": {
                 "@types/glob": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "align-columns",
     "displayName": "align-columns",
     "description": "Align multi columns",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "publisher": "jca02266",
     "engines": {
         "vscode": "^1.46.0"

--- a/src/align.ts
+++ b/src/align.ts
@@ -98,7 +98,7 @@ export function alignBySeparator(lines: LineObject[], cstr: string, addAfterSpac
 
                 lines[v.idx] = new LineObject(s, index, column);
             }
-            selections.push({line: v.idx, character: lines[v.idx].column})
+            selections.push({line: v.idx, character: lines[v.idx].column});
         });
     }
     return [selections, formatLine(lines)];

--- a/src/align.ts
+++ b/src/align.ts
@@ -1,10 +1,17 @@
 export class LineObject {
     str: string;
     lastindex: number;
-    constructor(line: string, lastindex: number = 0) {
+    column: number;
+    constructor(line: string, lastindex: number = 0, column: number = 0) {
         this.str = line;
         this.lastindex = lastindex;
+        this.column = column;
     }
+}
+
+export interface Selection {
+    line: number
+    character: number
 }
 
 export interface XS {
@@ -41,8 +48,10 @@ export function getColumnInfo1(lines: LineObject[], cstr: string): XS[] | undefi
     return xs;
 }
 
-export function alignBySeparator(lines: LineObject[], cstr: string, addAfterSpace: boolean): string {
+export function alignBySeparator(lines: LineObject[], cstr: string, addAfterSpace: boolean): [Selection[], string] {
     let xs;
+    const selections: Selection[] = [];
+
     while ((xs = getColumnInfo1(lines, cstr)) !== undefined) {
         // Retrieve the Most-left delimiter
         var mlchar = xs.min(function (v: XS): number { return v.column; }).char; // Most-left delimiter
@@ -80,17 +89,19 @@ export function alignBySeparator(lines: LineObject[], cstr: string, addAfterSpac
                 }
                 s = s.splice(index, delCount, "");
 
+                const column = index;
                 if (addAfterSpace) {
                     // just add a space after delimitor
                     s = s.splice(index, 0, ' ');
                     index += 1;
                 }
 
-                lines[v.idx] = new LineObject(s, index);
+                lines[v.idx] = new LineObject(s, index, column);
             }
+            selections.push({line: v.idx, character: lines[v.idx].column})
         });
     }
-    return formatLine(lines);
+    return [selections, formatLine(lines)];
 }
 
 // Extract information about delimiters (XS: index, column, character)

--- a/src/align.ts
+++ b/src/align.ts
@@ -48,9 +48,10 @@ export function getColumnInfo1(lines: LineObject[], cstr: string): XS[] | undefi
     return xs;
 }
 
-export function alignBySeparator(lines: LineObject[], cstr: string, addAfterSpace: boolean): [Selection[], string] {
+export function alignBySeparator(lines: LineObject[], cstr: string): [Selection[], string] {
     let xs;
     const selections: Selection[] = [];
+    const addAfterSpace = false;
 
     while ((xs = getColumnInfo1(lines, cstr)) !== undefined) {
         // Retrieve the Most-left delimiter

--- a/src/align.ts
+++ b/src/align.ts
@@ -41,7 +41,7 @@ export function getColumnInfo1(lines: LineObject[], cstr: string): XS[] | undefi
     return xs;
 }
 
-export function alignBySeparator(lines: LineObject[], cstr: string): string {
+export function alignBySeparator(lines: LineObject[], cstr: string, addAfterSpace: boolean): string {
     let xs;
     while ((xs = getColumnInfo1(lines, cstr)) !== undefined) {
         // Retrieve the Most-left delimiter
@@ -79,6 +79,12 @@ export function alignBySeparator(lines: LineObject[], cstr: string): string {
                     delCount++;
                 }
                 s = s.splice(index, delCount, "");
+
+                if (addAfterSpace) {
+                    // just add a space after delimitor
+                    s = s.splice(index, 0, ' ');
+                    index += 1;
+                }
 
                 lines[v.idx] = new LineObject(s, index);
             }

--- a/src/align.ts
+++ b/src/align.ts
@@ -55,10 +55,10 @@ export function alignBySeparator(lines: LineObject[], cstr: string): [Selection[
 
     while ((xs = getColumnInfo1(lines, cstr)) !== undefined) {
         // Retrieve the Most-left delimiter
-        var mlchar = xs.min(function (v: XS): number { return v.column; }).char; // Most-left delimiter
+        const mlchar = xs.min(function (v: XS): number { return v.column; }).char; // Most-left delimiter
 
         // Retrieve the Most-right column that matches the character Most-left delimiter
-        var mrcolumn = xs.max(function (v: XS): number {
+        const mrcolumn = xs.max(function (v: XS): number {
             if (mlchar === v.char) {
                 return v.column;
             }
@@ -66,7 +66,7 @@ export function alignBySeparator(lines: LineObject[], cstr: string): [Selection[
         }).column;  // Most-right column
 
         // Align the position of the delimiter to the Most-right one
-        var lenback = 0;
+        let lenback = 0;
         if (mlchar.indexChar(",)]}") !== -1) {
           // Align after ,, ), ], or }
           lenback = 1;
@@ -136,7 +136,7 @@ export function alignBySpace(lines: LineObject[]): string {
     let xs;
     while ((xs = getColumnInfo2(lines)) !== undefined) {
         // Retrieve the Most-right column that matches the space
-        var mrcolumn = xs.max(function (v: XS): number {
+        const mrcolumn = xs.max(function (v: XS): number {
             if (' ' !== v.char) {
                 return v.column;
             }
@@ -170,7 +170,7 @@ function formatLine(lines: LineObject[]) {
 
 
 function charWidth(s: string, index: number): 1|2 {
-    var codepoint = s.charCodeAt(index || 0);
+    const codepoint = s.charCodeAt(index || 0);
 
     // ASCII
     if (codepoint < 0x100) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,16 +13,21 @@ export async function alignColumns(editor: vscode.TextEditor, value: string) {
         lines.push(new align.LineObject(line));
     }
 
-    let newText;
+    let selections, newText;
 
     if (value.includes(' ') && value.trim() === '') {
         newText = align.alignBySpace(lines);
     } else {
         const afterSpace = / +$/.test(value);
-        newText = align.alignBySeparator(lines, value, afterSpace);
+        [selections, newText] = align.alignBySeparator(lines, value, afterSpace);
     }
 
     await vsc.replaceSelection(editor, newText);
+    if (selections) {
+        editor.selections = selections.map(s => {
+            return new vscode.Selection(s.line, s.character, s.line, s.character) }
+        );
+    }
 }
 
 function getSelectionGroup(editor: vscode.TextEditor): [number, vscode.Selection[]][] {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,8 +18,7 @@ export async function alignColumns(editor: vscode.TextEditor, value: string) {
     if (value.includes(' ') && value.trim() === '') {
         newText = align.alignBySpace(lines);
     } else {
-        const afterSpace = / +$/.test(value);
-        [selections, newText] = align.alignBySeparator(lines, value, afterSpace);
+        [selections, newText] = align.alignBySeparator(lines, value);
     }
 
     await vsc.replaceSelection(editor, newText);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,9 +13,15 @@ export async function alignColumns(editor: vscode.TextEditor, value: string) {
         lines.push(new align.LineObject(line));
     }
 
-    const newText = value.includes(' ') && value.trim() === '' ?
-        align.alignBySpace(lines) :
-        align.alignBySeparator(lines, value);
+    let newText;
+
+    if (value.includes(' ') && value.trim() === '') {
+        newText = align.alignBySpace(lines);
+    } else {
+        const afterSpace = / +$/.test(value);
+        newText = align.alignBySeparator(lines, value, afterSpace);
+    }
+
     await vsc.replaceSelection(editor, newText);
 }
 

--- a/src/testMocha/index.ts
+++ b/src/testMocha/index.ts
@@ -8,7 +8,7 @@ suite('Extension Test Suite', () => {
             const lines: align.LineObject[] = [
                 new align.LineObject('fo, bar=a,b', 0),
                 new align.LineObject('baz,quux=c,d', 0)];
-            const [selections, newline] = align.alignBySeparator(lines, ",=", false);
+            const [selections, newline] = align.alignBySeparator(lines, ",=");
             assert.deepStrictEqual(selections, [
                 {  line: 0, character: 4  }, // fo ,|bar =a,b
                 {  line: 1, character: 4  }, // baz,|quux=c,d

--- a/src/testMocha/index.ts
+++ b/src/testMocha/index.ts
@@ -3,7 +3,7 @@ import * as jsu from '../js-utils';
 import * as align from '../align';
 
 suite('Extension Test Suite', () => {
-    suite('extension', () => {
+    suite('align', () => {
         test('alignBySeparator', () => {
             const lines: align.LineObject[] = [
                 new align.LineObject('fo, bar=a,b', 0),

--- a/src/testMocha/index.ts
+++ b/src/testMocha/index.ts
@@ -4,11 +4,19 @@ import * as align from '../align';
 
 suite('Extension Test Suite', () => {
     suite('extension', () => {
-        test('getColumnInfo1', () => {
+        test('alignBySeparator', () => {
             const lines: align.LineObject[] = [
                 new align.LineObject('fo, bar=a,b', 0),
                 new align.LineObject('baz,quux=c,d', 0)];
-            const newline = align.alignBySeparator(lines, ",=", false);
+            const [selections, newline] = align.alignBySeparator(lines, ",=", false);
+            assert.deepStrictEqual(selections, [
+                {  line: 0, character: 4  }, // fo ,|bar =a,b
+                {  line: 1, character: 4  }, // baz,|quux=c,d
+                {  line: 0, character: 9  }, // baz,quux=|c,d
+                {  line: 1, character: 9  }, // baz,quux=|c,d
+                {  line: 0, character: 11 }, // baz,quux=c,|d
+                {  line: 1, character: 11 }  // baz,quux=c,|d
+            ]);
             assert.strictEqual(newline, "fo ,bar =a,b\nbaz,quux=c,d");
         });
         test('getColumnInfo1', () => {
@@ -18,7 +26,7 @@ suite('Extension Test Suite', () => {
             const xs: align.XS[] | undefined = align.getColumnInfo1(lines, ',');
             assert.strictEqual(xs, undefined);
         });
-        test('getColumnInfo1', () => {
+        test('evaluate each step of alignBySeparator()', () => {
             const lines: align.LineObject[] = [
                 new align.LineObject('fo, bar=a,b', 0),
                 new align.LineObject('baz,quux=c,d', 0)];

--- a/src/testMocha/index.ts
+++ b/src/testMocha/index.ts
@@ -8,7 +8,7 @@ suite('Extension Test Suite', () => {
             const lines: align.LineObject[] = [
                 new align.LineObject('fo, bar=a,b', 0),
                 new align.LineObject('baz,quux=c,d', 0)];
-            const newline = align.alignBySeparator(lines, ",=");
+            const newline = align.alignBySeparator(lines, ",=", false);
             assert.strictEqual(newline, "fo ,bar =a,b\nbaz,quux=c,d");
         });
         test('getColumnInfo1', () => {


### PR DESCRIPTION
If a delimiter is followed by a space, add a space after the delimiter

```
fo,bar=a,b
baz,quux=c,d
```

aligned by ",="

```
fo ,bar =a,b
baz,quux=c,d
```

aligned by ",= "  (add just a space)

```
fo , bar = a, b
baz, quux= c, d
```